### PR TITLE
fix: type and export interceptor public methods

### DIFF
--- a/src/fetchin.ts
+++ b/src/fetchin.ts
@@ -7,12 +7,13 @@ import { requestTransformers } from './transformer/request'
 import { bearerAuthInterceptor, useRequestInterceptor } from './interceptor/request'
 import { useResponseInterceptor } from './interceptor/response'
 
-const DEFAULT_CONFIG = {
+const DEFAULT_CONFIG: FetchinConfig = {
   transformRequest: requestTransformers,
   transformResponse: responseTransformers,
   requestInterceptors: [{ onFulfilled: bearerAuthInterceptor }],
   responseInterceptors: [],
 }
+
 export class Fetchin {
   private axiosInstance!: AxiosInstance
   private config: FetchinConfig

--- a/src/fetchin.ts
+++ b/src/fetchin.ts
@@ -1,9 +1,9 @@
 import merge from 'lodash.merge'
-import axios, { AxiosInstance, type AxiosResponse } from 'axios'
+import axios, { AxiosInstance } from 'axios'
 
+import type { FetchinConfig, FetchinResponse } from './types'
 import { responseTransformers } from './transformer/response'
 import { requestTransformers } from './transformer/request'
-import type { FetchinConfig } from './types'
 import { bearerAuthInterceptor, useRequestInterceptor } from './interceptor/request'
 import { useResponseInterceptor } from './interceptor/response'
 
@@ -50,14 +50,17 @@ export class Fetchin {
   /**
    * get request
    */
-  get<T = any, R = AxiosResponse<T>, D = any>(url: string, config?: FetchinConfig<D>): Promise<R> {
+  get<T = any, R = FetchinResponse<T>, D = any>(
+    url: string,
+    config?: FetchinConfig<D>,
+  ): Promise<R> {
     return this.axiosInstance.get(url, config)
   }
 
   /**
    * post request
    */
-  post<T = any, R = AxiosResponse<T>, D = any>(
+  post<T = any, R = FetchinResponse<T>, D = any>(
     url: string,
     data?: D,
     config?: FetchinConfig<D>,
@@ -68,7 +71,7 @@ export class Fetchin {
   /**
    * put request
    */
-  put<T = any, R = AxiosResponse<T>, D = any>(
+  put<T = any, R = FetchinResponse<T>, D = any>(
     url: string,
     data?: D,
     config?: FetchinConfig<D>,
@@ -79,7 +82,7 @@ export class Fetchin {
   /**
    * delete request
    */
-  delete<T = any, R = AxiosResponse<T>, D = any>(
+  delete<T = any, R = FetchinResponse<T>, D = any>(
     url: string,
     config?: FetchinConfig<D>,
   ): Promise<R> {
@@ -89,7 +92,7 @@ export class Fetchin {
   /**
    * post form request
    */
-  postForm<T = any, R = AxiosResponse<T>, D = any>(
+  postForm<T = any, R = FetchinResponse<T>, D = any>(
     url: string,
     data?: D,
     config?: FetchinConfig<D>,
@@ -100,7 +103,7 @@ export class Fetchin {
   /**
    * put form request
    */
-  putForm<T = any, R = AxiosResponse<T>, D = any>(
+  putForm<T = any, R = FetchinResponse<T>, D = any>(
     url: string,
     data?: D,
     config?: FetchinConfig<D>,
@@ -108,7 +111,7 @@ export class Fetchin {
     return this.axiosInstance.putForm(url, data, config)
   }
 
-  request<T = any, R = AxiosResponse<T>, D = any>(config: FetchinConfig<D>): Promise<R> {
+  request<T = any, R = FetchinResponse<T>, D = any>(config: FetchinConfig<D>): Promise<R> {
     return this.axiosInstance.request(config)
   }
 

--- a/src/fetchin.ts
+++ b/src/fetchin.ts
@@ -1,7 +1,13 @@
 import merge from 'lodash.merge'
 import axios, { AxiosInstance } from 'axios'
 
-import type { FetchinConfig, FetchinResponse } from './types'
+import type {
+  FetchinConfig,
+  FetchinInterceptor,
+  FetchinRequestInterceptorFulfilled,
+  FetchinResponse,
+  FetchinResponseInterceptorFulfilled,
+} from './types'
 import { responseTransformers } from './transformer/response'
 import { requestTransformers } from './transformer/request'
 import { bearerAuthInterceptor, useRequestInterceptor } from './interceptor/request'
@@ -38,14 +44,6 @@ export class Fetchin {
         useResponseInterceptor(this.axiosInstance, onFulfilled, onRejected, options)
       })
     }
-  }
-
-  /**
-   * update config, will recreate instance
-   */
-  updateConfig(config: FetchinConfig) {
-    this.config = merge(this.config, config)
-    this.createInstance()
   }
 
   /**
@@ -121,5 +119,21 @@ export class Fetchin {
    */
   getUri(config?: FetchinConfig): string {
     return this.axiosInstance.getUri(config)
+  }
+
+  /**
+   * add request interceptor
+   */
+  useRequestInterceptor(interceptor: FetchinInterceptor<FetchinRequestInterceptorFulfilled>) {
+    const { onFulfilled, onRejected, options } = interceptor
+    return useRequestInterceptor(this.axiosInstance, onFulfilled, onRejected, options)
+  }
+
+  /**
+   * add response interceptor
+   */
+  useResponseInterceptor(interceptor: FetchinInterceptor<FetchinResponseInterceptorFulfilled>) {
+    const { onFulfilled, onRejected, options } = interceptor
+    return useResponseInterceptor(this.axiosInstance, onFulfilled, onRejected, options)
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,4 @@
 export * from './fetchin'
+
+export { useRequestInterceptor, ejectRequestInterceptor } from './interceptor/request'
+export { useResponseInterceptor, ejectResponseInterceptor } from './interceptor/response'

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,1 @@
 export * from './fetchin'
-
-export { useRequestInterceptor, ejectRequestInterceptor } from './interceptor/request'
-export { useResponseInterceptor, ejectResponseInterceptor } from './interceptor/response'


### PR DESCRIPTION
- change the response type to `FetchinResponse`
- export `use` and `eject` methods of interceptors

这里有个问题需要讨论，导出了以下四个方法给用户后：

- `useRequestInterceptor`
- `ejectRequestInterceptor`
- `useResponseInterceptor`
- `ejectResponseInterceptor`

这些方法需要的第一个参数是 axios 实例从何得到？

- 在 `Fetchin` 类中提供一个 `getter` 来获得当前实例的内置 `axiosIntance`？
- 或是还是在 `Fetchin` 类中提供它们的包装方法？

但是暴露 `use` 和 `eject` 后都会存在一个问题，就是用户调用 `updateConfig` 之后产生的新 `axiosInstance` 上将丢失这些手动添加的拦截器

又或是我们不提供上述的方法，限制用户只能通过配置项来传入自定义拦截器？